### PR TITLE
Add Apple-style landing page sample

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Apple Style Sample</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav class="navbar">
+        <ul class="nav-links">
+            <li><a href="#">Home</a></li>
+            <li><a href="#products">Products</a></li>
+            <li><a href="#support">Support</a></li>
+        </ul>
+    </nav>
+
+    <section class="hero">
+        <div class="hero-content">
+            <h1>Think Different</h1>
+            <p>Innovation meets simplicity.</p>
+        </div>
+        <img src="https://via.placeholder.com/1600x600" alt="Hero image">
+    </section>
+
+    <section id="products" class="products">
+        <div class="product">
+            <img src="https://via.placeholder.com/400x300" alt="Product 1">
+            <h2>Product 1</h2>
+            <p>Beautifully designed for every day.</p>
+        </div>
+        <div class="product">
+            <img src="https://via.placeholder.com/400x300" alt="Product 2">
+            <h2>Product 2</h2>
+            <p>Powerful performance in a sleek package.</p>
+        </div>
+        <div class="product">
+            <img src="https://via.placeholder.com/400x300" alt="Product 3">
+            <h2>Product 3</h2>
+            <p>The future is now.</p>
+        </div>
+    </section>
+
+    <footer class="footer">
+        <p>&copy; 2024 Sample Corporation. All rights reserved.</p>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,2 @@
+// Placeholder for future interactive features
+console.log('Page loaded');

--- a/style.css
+++ b/style.css
@@ -1,0 +1,74 @@
+body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif;
+    background: #fff;
+    color: #333;
+}
+
+.navbar {
+    display: flex;
+    justify-content: center;
+    padding: 20px 0;
+    border-bottom: 1px solid #eee;
+}
+
+.nav-links {
+    list-style: none;
+    display: flex;
+    gap: 30px;
+    margin: 0;
+    padding: 0;
+}
+
+.nav-links a {
+    text-decoration: none;
+    color: #333;
+    font-weight: 500;
+}
+
+.hero {
+    position: relative;
+    text-align: center;
+    margin-bottom: 60px;
+}
+
+.hero img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.hero-content {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: #000;
+}
+
+.hero-content h1 {
+    font-size: 3rem;
+    margin-bottom: 10px;
+}
+
+.products {
+    display: flex;
+    justify-content: center;
+    gap: 40px;
+    padding: 0 20px 80px;
+}
+
+.product {
+    max-width: 400px;
+    text-align: center;
+}
+
+.product h2 {
+    margin: 20px 0 10px;
+}
+
+.footer {
+    text-align: center;
+    padding: 40px 0;
+    border-top: 1px solid #eee;
+}


### PR DESCRIPTION
## Summary
- Add minimal Apple-inspired webpage with navigation, hero, product highlights, and footer
- Style page with clean typography and spacing
- Include placeholder script for future enhancements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dd638b5088328ae1f6341d2ebcb41