### PR TITLE
feat: enhance hero section with Apple-style navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,13 +9,38 @@
 <body>
     <nav class="navbar">
         <ul class="nav-links">
-            <li><a href="#hero">Home</a></li>
-            <li><a href="#products">Products</a></li>
+            <li><a href="#">Mac</a></li>
+            <li><a href="#">iPad</a></li>
+            <li><a href="#">iPhone</a></li>
+            <li><a href="#">Watch</a></li>
+            <li><a href="#">Vision</a></li>
             <li><a href="#support">Support</a></li>
         </ul>
     </nav>
 
     <section id="hero" class="hero">
+        <ul class="hero-categories">
+            <li>
+                <img src="https://via.placeholder.com/40" alt="Mac">
+                <span>Mac</span>
+            </li>
+            <li>
+                <img src="https://via.placeholder.com/40" alt="iPad">
+                <span>iPad</span>
+            </li>
+            <li>
+                <img src="https://via.placeholder.com/40" alt="iPhone">
+                <span>iPhone</span>
+            </li>
+            <li>
+                <img src="https://via.placeholder.com/40" alt="Watch">
+                <span>Watch</span>
+            </li>
+            <li>
+                <img src="https://via.placeholder.com/40" alt="Vision">
+                <span>Vision</span>
+            </li>
+        </ul>
         <div class="hero-content">
             <h1>Think Different</h1>
             <p>Innovation meets simplicity.</p>

--- a/style.css
+++ b/style.css
@@ -28,6 +28,8 @@ body {
     gap: 30px;
     margin: 0;
     padding: 0;
+    flex-wrap: wrap;
+    justify-content: center;
 }
 
 .nav-links a {
@@ -39,6 +41,29 @@ body {
 .hero {
     text-align: center;
     margin-bottom: 60px;
+}
+
+.hero-categories {
+    list-style: none;
+    display: flex;
+    justify-content: center;
+    gap: 40px;
+    padding: 0;
+    margin: 20px 0;
+    flex-wrap: wrap;
+}
+
+.hero-categories li {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-size: 0.875rem;
+}
+
+.hero-categories img {
+    width: 40px;
+    height: 40px;
+    margin-bottom: 5px;
 }
 
 .hero img {
@@ -74,6 +99,10 @@ body {
 .product {
     flex: 0 1 220px;
     text-align: center;
+    padding: 20px;
+    border-radius: 20px;
+    background: #fff;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
 }
 
 .product img {
@@ -82,7 +111,7 @@ body {
     border-radius: 20px;
     object-fit: cover;
     margin: 0 auto;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    box-shadow: none;
 }
 
 .product h2 {
@@ -108,6 +137,12 @@ body {
     .products {
         flex-direction: column;
         gap: 60px;
+    }
+    .hero-categories {
+        gap: 20px;
+    }
+    .nav-links {
+        gap: 15px;
     }
 }
 


### PR DESCRIPTION
## Summary
- replace nav menu with Apple-style product categories
- add icon-based category list in hero section
- style product cards with premium shadow and mobile-friendly flex

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e2301955c832884ca8181b9c991ab